### PR TITLE
refine registration flow and clean up home hero CTAs

### DIFF
--- a/feedtheneed/frontend/src/pages/home-landing/components/HeroSection.jsx
+++ b/feedtheneed/frontend/src/pages/home-landing/components/HeroSection.jsx
@@ -1,11 +1,7 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
-import Button from '../../../components/ui/Button';
 import Image from '../../../components/AppImage';
 
 const HeroSection = () => {
-  const navigate = useNavigate();
-
   return (
     <section className="relative bg-gradient-to-br from-primary/5 via-background to-secondary/5 py-20 lg:py-32">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -19,22 +15,6 @@ const HeroSection = () => {
             <p className="text-lg sm:text-xl text-text-secondary mb-8 max-w-xl mx-auto lg:mx-0">
               Connecting surplus food with those who need it most.
             </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start">
-              <Button
-                variant="default"
-                size="lg"
-                onClick={() => navigate('/registration')}
-              >
-                Get Started
-              </Button>
-              <Button
-                variant="outline"
-                size="lg"
-                onClick={() => navigate('/login')}
-              >
-                Login
-              </Button>
-            </div>
           </div>
 
           {/* Hero Image */}

--- a/feedtheneed/frontend/src/pages/registration/components/RegistrationForm.jsx
+++ b/feedtheneed/frontend/src/pages/registration/components/RegistrationForm.jsx
@@ -22,8 +22,7 @@ const RegistrationForm = () => {
 
   const roleOptions = [
     { value: 'donor', label: 'Donor' },
-    { value: 'recipient', label: 'Recipient' },
-    { value: 'admin', label: 'Admin' }
+    { value: 'recipient', label: 'Recipient' }
   ];
 
   const handleInputChange = (e) => {

--- a/feedtheneed/frontend/src/pages/registration/components/RegistrationSuccess.jsx
+++ b/feedtheneed/frontend/src/pages/registration/components/RegistrationSuccess.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import Icon from '../../../components/AppIcon';
 import Button from '../../../components/ui/Button';
 
 const RegistrationSuccess = () => {
-  const location = useLocation();
-  const { email, role } = location.state || {};
   return (
     <div className="max-w-md mx-auto text-center">
       <div className="w-20 h-20 bg-success/10 rounded-full flex items-center justify-center mx-auto mb-6">
@@ -13,74 +11,22 @@ const RegistrationSuccess = () => {
       </div>
       
       <h2 className="text-2xl font-bold text-text-primary mb-4">
-        Welcome to FeedTheNeed!
+        Registration Successful!
       </h2>
       
-      <p className="text-text-secondary mb-6">
-        Your account has been created successfully. We've sent a verification email to:
+      <p className="text-text-secondary mb-8">
+        Your account has been created successfully. You can now sign in to start using FeedTheNeed.
       </p>
       
-      <div className="bg-muted p-4 rounded-lg mb-6">
-        <p className="font-medium text-text-primary">{email}</p>
-      </div>
-      
-      <div className="bg-accent/10 border border-accent/20 rounded-lg p-4 mb-6">
-        <div className="flex items-start space-x-3">
-          <Icon name="Mail" size={20} className="text-accent mt-0.5 flex-shrink-0" />
-          <div className="text-left">
-            <h4 className="font-medium text-text-primary mb-1">Check Your Email</h4>
-            <p className="text-sm text-text-secondary">
-              Click the verification link in your email to activate your account and start {role === 'donor' ? 'donating food' : 'receiving donations'}.
-            </p>
-          </div>
-        </div>
-      </div>
-      
-      <div className="space-y-4">
-        <div className="flex items-center space-x-4">
-          <Button
-            variant="outline"
-            fullWidth
-            asChild
-          >
-            <Link to="/login">
-              Sign In Instead
-            </Link>
-          </Button>
-          
-          <Button
-            variant="ghost"
-            fullWidth
-            asChild
-          >
-            <Link to="/home-landing">
-              Back to Home
-            </Link>
-          </Button>
-        </div>
-      </div>
-      
-      <div className="mt-8 p-4 bg-primary/5 rounded-lg">
-        <h4 className="font-medium text-primary mb-2">What's Next?</h4>
-        <ul className="text-sm text-text-secondary space-y-1 text-left">
-          <li className="flex items-center">
-            <Icon name="Check" size={14} className="text-success mr-2 flex-shrink-0" />
-            Verify your email address
-          </li>
-          <li className="flex items-center">
-            <Icon name="Check" size={14} className="text-success mr-2 flex-shrink-0" />
-            Complete your profile setup
-          </li>
-          <li className="flex items-center">
-            <Icon name="Check" size={14} className="text-success mr-2 flex-shrink-0" />
-            {role === 'donor' ? 'Start posting food donations' : 'Browse available donations'}
-          </li>
-        </ul>
-      </div>
-      
-      <p className="text-xs text-text-secondary mt-6">
-        Didn't receive the email? Check your spam folder or contact support.
-      </p>
+      <Button
+        variant="default"
+        className="w-full"
+        asChild
+      >
+        <Link to="/login">
+          Go to Login
+        </Link>
+      </Button>
     </div>
   );
 };


### PR DESCRIPTION
Removed "Admin" from registration role options to prevent public admin signups.
Simplified registration success page:
Replaced verification-focused content with a simple success message.
Added a single “Go to Login” button redirecting to /login.
Removed duplicate “Get Started” and “Login” buttons from the home page hero since these are already in the navigation.

Changes
pages/registration/components/RegistrationForm.jsx: Removed admin from roleOptions.
pages/registration/components/RegistrationSuccess.jsx: Simplified UI and copy; added single login CTA.
pages/home-landing/components/HeroSection.jsx: Removed redundant CTAs; cleaned unused imports and variables.

Rationale
Prevents unauthorized admin account creation.
Streamlines UX by reducing duplicate CTAs and post-registration friction.
Keeps navigation the single source for auth actions.

Centralize API URLs in a utils/constants file as previously suggested.
This PR keeps existing endpoints unchanged to avoid any backend impact.
I’ll move URLs to constants in a separate PR after this merges.

Since we need to speed up the other API integrations, quick approval would be appreciated.